### PR TITLE
Allow users to add videos to tournaments

### DIFF
--- a/app/Http/Controllers/VideosController.php
+++ b/app/Http/Controllers/VideosController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Tournament;
+use App\Video;
+use App\Http\Requests;
+use Illuminate\Http\Request;
+
+class VideosController extends Controller
+{
+    /**
+     * Saves new video.
+     * @param Requests\VideoRequest $request
+     * @return redirects
+     */
+    public function store(Requests\VideoRequest $request)
+    {
+        $tournament = Tournament::withTrashed()->findOrFail($request->get('tournament_id'));
+        $this->authorize('logged_in', Tournament::class, $request->user());
+
+        $video = Video::create([
+            'tournament_id' => $tournament->id,
+            'user_id' => $request->user()->id,
+            'video_id' => $request->get('video_id')
+        ]);
+        $video->populateFromYoutube();
+
+        // redirecting to tournament
+        return redirect()->route('tournaments.show.slug', [$tournament->id, $tournament->seoTitle()])
+            ->with('message', 'Video added.');
+    }
+
+    public function destroy(Request $request, $id)
+    {
+        $video = Video::where('id', $id)->first();
+        $this->authorize('delete', $video, $request->user());
+
+        $tournament = $video->tournament;
+        Video::destroy($id);
+
+        // redirecting to tournament
+        return redirect()->route('tournaments.show.slug', [$tournament->id, $tournament->seoTitle()])
+            ->with('message', 'Video deleted.');
+    }
+}

--- a/app/Http/Requests/VideoRequest.php
+++ b/app/Http/Requests/VideoRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Http\Requests\Request;
+
+class VideoRequest extends Request
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        $rules = [
+            'video_id' => 'required'
+        ];
+
+        return $rules;
+    }
+}

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -38,6 +38,9 @@ Route::post('tournaments/{id}/conclude/manual', 'TournamentsController@concludeM
 Route::post('tournaments/{id}/conclude/nrtm', 'TournamentsController@concludeNRTM');
 Route::get('tournaments/{id}/{slug}', 'TournamentsController@show')->name('tournaments.show.slug');
 
+Route::post('videos', 'VideosController@store');
+Route::delete('videos/{id}', 'VideosController@destroy');
+
 Route::get('/oauth2/redirect', 'NetrunnerDBController@login');
 Route::get('/logout', 'NetrunnerDBController@logout');
 

--- a/app/Policies/VideoPolicy.php
+++ b/app/Policies/VideoPolicy.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Policies;
+
+use App\User;
+use App\Video;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class VideoPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Create a new policy instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+    }
+
+    public function delete(User $user, Video $video) {
+        return $user->admin || $user->id == $video->user_id || $user->id == $video->tournament->creator;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -18,6 +18,7 @@ class AuthServiceProvider extends ServiceProvider
         'App\Tournament' => 'App\Policies\TournamentPolicy',
         Entry::class => EntryPolicy::class,
         'App\Model' => 'App\Policies\ModelPolicy',
+        'App\Video' => 'App\Policies\VideoPolicy'
     ];
 
     /**

--- a/app/Tournament.php
+++ b/app/Tournament.php
@@ -27,6 +27,10 @@ class Tournament extends Model
         return $this->hasMany(Entry::class, 'tournament_id', 'id');
     }
 
+    public function videos() {
+        return $this->hasMany(Video::class, 'tournament_id', 'id');
+    }
+
     public function cardpool() {
         return $this->hasOne(CardPack::class, 'id', 'cardpool_id');
     }

--- a/app/Video.php
+++ b/app/Video.php
@@ -15,12 +15,29 @@ class Video extends Model
         return $this->belongsTo(Tournament::class, 'tournament_id', 'id');
     }
 
-    public function populateFromYoutube() {
-        $data = Youtube::getVideoInfo($this->video_id);
-        return $this->update([
-            'video_title' => $data->snippet->title,
-            'thumbnail_url' => $data->snippet->thumbnails->default->url,
-            'channel_name' => $data->snippet->channelTitle
-        ]);
+    public static function youtubeLookup($input) {
+        if(strlen($input) == 11) {
+            // video ID
+            $video_id = $input;
+        } else {
+            // video URL
+            try {
+                $video_id = Youtube::parseVidFromURL($input);
+            } catch(Exception $e) {
+                return false;
+            }
+        }
+        $data = Youtube::getVideoInfo($video_id);
+
+        if($data) {
+            return [
+                'video_id' => $video_id,
+                'video_title' => $data->snippet->title,
+                'thumbnail_url' => $data->snippet->thumbnails->default->url,
+                'channel_name' => $data->snippet->channelTitle
+            ];
+        } else {
+            return false;
+        }
     }
 }

--- a/app/Video.php
+++ b/app/Video.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use Alaouy\Youtube\Facades\Youtube;
+
+class Video extends Model
+{
+    public $timestamps = true;
+    protected $fillable = ['video_title', 'video_id', 'thumbnail_url', 'channel_name', 'tournament_id', 'user_id'];
+    protected $dates = ['created_at', 'updated_at'];
+
+    public function tournament() {
+        return $this->belongsTo(Tournament::class, 'tournament_id', 'id');
+    }
+
+    public function populateFromYoutube() {
+        $data = Youtube::getVideoInfo($this->video_id);
+        return $this->update([
+            'video_title' => $data->snippet->title,
+            'thumbnail_url' => $data->snippet->thumbnails->default->url,
+            'channel_name' => $data->snippet->channelTitle
+        ]);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "webpatser/laravel-countries": "dev-master",
         "laravelcollective/html": "^5.0",
         "oriceon/oauth-5-laravel": "dev-master",
-        "haleks/laravel-markdown": "^0.3.0"
+        "haleks/laravel-markdown": "^0.3.0",
+        "alaouy/youtube": "dev-master"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,55 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "92962e0cee7355bba9507b08f6881879",
-    "content-hash": "f833a5bbeebc54f7de5bb6e3a731a828",
+    "hash": "0f5d9b85b00789083274fec7a6fa3b23",
+    "content-hash": "9762c7fa4851b400858ee601bca7d39a",
     "packages": [
+        {
+            "name": "alaouy/youtube",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/alaouy/Youtube.git",
+                "reference": "3be7b0d45e1164598a215bc644bb0911d2da2962"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/alaouy/Youtube/zipball/3be7b0d45e1164598a215bc644bb0911d2da2962",
+                "reference": "3be7b0d45e1164598a215bc644bb0911d2da2962",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "3.7.*@stable"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Alaouy\\Youtube\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mustapha Alaouy",
+                    "email": "alaouym@gmail.com"
+                }
+            ],
+            "description": "Laravel PHP Facade/Wrapper for the Youtube Data API v3",
+            "keywords": [
+                "alaouy",
+                "api",
+                "laravel",
+                "video",
+                "youtube"
+            ],
+            "time": "2016-12-06 15:20:40"
+        },
         {
             "name": "classpreloader/classpreloader",
             "version": "3.1.0",
@@ -3534,7 +3580,8 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "webpatser/laravel-countries": 20,
-        "oriceon/oauth-5-laravel": 20
+        "oriceon/oauth-5-laravel": 20,
+        "alaouy/youtube": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/config/app.php
+++ b/config/app.php
@@ -159,7 +159,8 @@ return [
         'Webpatser\Countries\CountriesServiceProvider',
         Collective\Html\HtmlServiceProvider::class,
         Artdarek\OAuth\OAuthServiceProvider::class,
-        Haleks\Markdown\MarkdownServiceProvider::class
+        Haleks\Markdown\MarkdownServiceProvider::class,
+        Alaouy\Youtube\YoutubeServiceProvider::class
     ],
 
     /*
@@ -209,7 +210,8 @@ return [
         'Form' => Collective\Html\FormFacade::class,
         'Html' => Collective\Html\HtmlFacade::class,
         'OAuth2' => Artdarek\OAuth\Facade\OAuth::class,
-        'Markdown' => Haleks\Markdown\Facades\Markdown::class
+        'Markdown' => Haleks\Markdown\Facades\Markdown::class,
+        'Youtube'=> Alaouy\Youtube\Facades\Youtube::class
     ],
 
 ];

--- a/config/youtube.php
+++ b/config/youtube.php
@@ -1,0 +1,6 @@
+<?php
+
+// This can be the same key as the Google Maps api key, but Youtube should be enabled on it.
+return array(
+    'KEY' => env('GOOGLE_MAPS_API')
+);

--- a/database/migrations/2016_12_15_204650_create_videos_table.php
+++ b/database/migrations/2016_12_15_204650_create_videos_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateVideosTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('videos', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('video_id');
+            $table->string('video_title');
+            $table->integer('tournament_id')->unsigned();
+            $table->foreign('tournament_id')->references('id')->on('tournaments');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('videos');
+    }
+}

--- a/database/migrations/2016_12_23_141457_add_data_to_videos.php
+++ b/database/migrations/2016_12_23_141457_add_data_to_videos.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddDataToVideos extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('videos', function (Blueprint $table) {
+            $table->integer('user_id')->unsigned()->references('id')->on('users');
+            $table->string('thumbnail_url');
+            $table->string('channel_name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('videos', function (Blueprint $table) {
+          $table->dropColumn('user_id');
+          $table->dropColumn('thumbnail_url');
+          $table->dropColumn('channel_name');
+        });
+    }
+}

--- a/resources/assets/js/abr-main.js
+++ b/resources/assets/js/abr-main.js
@@ -173,6 +173,33 @@ function toggleEntriesEdit(value) {
     }
 }
 
+// toggle adding videos on tournament view page
+function toggleVideoAdd(value) {
+    if (value) {
+        $('#section-add-videos').removeClass('hidden-xs-up');
+        $('#button-done-videos').removeClass('hidden-xs-up');
+        $('#button-add-videos').addClass('hidden-xs-up');
+    } else {
+        $('#section-add-videos').addClass('hidden-xs-up');
+        $('#button-done-videos').addClass('hidden-xs-up');
+        $('#button-add-videos').removeClass('hidden-xs-up');
+    }
+}
+
+// toggle video player
+function watchVideo(videoId) {
+    if(videoId) {
+        $('#section-watch-video').removeClass('hidden-xs-up')
+        $('#section-video-player').html('<iframe width="480" height="270" src="//www.youtube.com/embed/' + videoId + '" frameborder="0" allowfullscreen></iframe>')
+        $('html, body').animate({
+            scrollTop: $("#section-watch-video").offset().top - 60
+        }, 500);
+    } else {
+        $('#section-watch-video').addClass('hidden-xs-up')
+        $('#section-video-player').empty()
+    }
+}
+
 // recalculating deck names from IDs while adding manually entries
 function recalculateDeckNames() {
     var corp = document.getElementById('corp_deck_identity'),

--- a/resources/views/tournaments/partials/videos.blade.php
+++ b/resources/views/tournaments/partials/videos.blade.php
@@ -1,0 +1,32 @@
+{{--table of entries for tournament details page--}}
+<table class="table table-sm table-striped abr-table" id="{{ $id }}">
+    <tbody>
+    @for ($i = 0; $i < count($videos); $i++)
+        <tr>
+            <td>
+                <a href="#" onClick="watchVideo('{{ $videos[$i]->video_id }}')">
+                    <img src="{{ $videos[$i]->thumbnail_url }}"/>
+                </a>
+            </td>
+            <td>
+                <b>
+                    <a href="#" onClick="watchVideo('{{ $videos[$i]->video_id }}')">
+                        {{ $videos[$i]->video_title }}
+                    </a>
+                </b>
+                <br/>{{ $videos[$i]->channel_name }}
+            </td>
+
+            @if ($user && ($user->admin || $user->id == $videos[$i]->user_id || $user->id == $videos[$i]->tournament->creator))
+                <td>
+                    {!! Form::open(['method' => 'DELETE', 'url' => "/videos/{$videos[$i]->id}"]) !!}
+                        {!! Form::button('<i class="fa fa-trash" aria-hidden="true"></i>', array('type' => 'submit', 'class' => 'btn btn-danger btn-xs delete-video')) !!}
+                    {!! Form::close() !!}
+                </td>
+            @else
+                <td></td>
+            @endif
+        </tr>
+    @endfor
+    </tbody>
+</table>

--- a/resources/views/tournaments/view.blade.php
+++ b/resources/views/tournaments/view.blade.php
@@ -257,8 +257,8 @@
                 </div>
             @endif
             {{--Videos--}}
-            <div class="bracket">
             @if ($tournament->concluded)
+            <div class="bracket">
                 <h5>
                     <i class="fa fa-video-camera" aria-hidden="true"></i>
                     Videos
@@ -272,7 +272,7 @@
                         onclick="toggleVideoAdd(false)">
                     <i class="fa fa-check" aria-hidden="true"></i> Done
                 </button>
-                <div id="section-add-videos" class="hidden-xs-up small-text">
+                <div id="section-add-videos" class="hidden-xs-up">
                     <hr/>
                     <div class="p-b-1">
                         Add a Youtube video
@@ -281,7 +281,7 @@
                         'class' => 'form-inline']) !!}
                         {!! Form::hidden('tournament_id', $tournament->id) !!}
                         <div class="form-group">
-                            {!! Form::label('video_id', 'Youtube Video ID') !!}
+                            {!! Form::label('video_id', 'Youtube Video ID or URL', ['class' => 'small-text']) !!}
                             {!! Form::text('video_id', '', ['class' => 'form-control']) !!}
                         </div><br/>
                         {!! Form::button('Add video', array('type' => 'submit',
@@ -305,8 +305,8 @@
                     </p>
                     <div id="section-video-player"></div>
                 </div>
-            @endif
             </div>
+            @endif
             {{--Results--}}
             <div class="bracket">
             @if ($tournament->concluded)

--- a/resources/views/tournaments/view.blade.php
+++ b/resources/views/tournaments/view.blade.php
@@ -256,6 +256,57 @@
                     </div>
                 </div>
             @endif
+            {{--Videos--}}
+            <div class="bracket">
+            @if ($tournament->concluded)
+                <h5>
+                    <i class="fa fa-video-camera" aria-hidden="true"></i>
+                    Videos
+                </h5>
+                {{--Add video--}}
+                <button class="btn btn-primary btn-xs" id="button-add-videos"
+                        onclick="toggleVideoAdd(true)">
+                    <i class="fa fa-video-camera" aria-hidden="true"></i> Add videos
+                </button>
+                <button class="btn btn-primary btn-xs hidden-xs-up" id="button-done-videos"
+                        onclick="toggleVideoAdd(false)">
+                    <i class="fa fa-check" aria-hidden="true"></i> Done
+                </button>
+                <div id="section-add-videos" class="hidden-xs-up small-text">
+                    <hr/>
+                    <div class="p-b-1">
+                        Add a Youtube video
+                    </div>
+                    {!! Form::open(['method' => 'POST', 'url' => "/videos",
+                        'class' => 'form-inline']) !!}
+                        {!! Form::hidden('tournament_id', $tournament->id) !!}
+                        <div class="form-group">
+                            {!! Form::label('video_id', 'Youtube Video ID') !!}
+                            {!! Form::text('video_id', '', ['class' => 'form-control']) !!}
+                        </div><br/>
+                        {!! Form::button('Add video', array('type' => 'submit',
+                            'class' => 'btn btn-success btn-xs', 'id' => 'button-add-video')) !!}
+                    {!! Form::close() !!}
+                </div>
+                <hr/>
+                {{--List of videos--}}
+                @if (count($tournament->videos) > 0)
+                  @include('tournaments.partials.videos',
+                      ['videos' => $tournament->videos, 'creator' => $tournament->creator, 'id' => 'videos'])
+                @else
+                    <p><em id="no-videos">no videos yet</em></p>
+                @endif
+                <div id="section-watch-video" class="hidden-xs-up">
+                    <hr/>
+                    <p>
+                        <button class="btn btn-danger btn-xs" onclick="watchVideo(false)">
+                            <i class="fa fa-window-close" aria-hidden="true"></i> Close
+                        </button>
+                    </p>
+                    <div id="section-video-player"></div>
+                </div>
+            @endif
+            </div>
             {{--Results--}}
             <div class="bracket">
             @if ($tournament->concluded)
@@ -597,4 +648,3 @@
         </script>
     @endif
 @stop
-


### PR DESCRIPTION
Any logged in user can add a video to a tournament. They must enter a Youtube video ID (Youtube is all that is supported for now) and the record is created, and title, thumbnail and channel name are populated from the Youtube API.

The video creator, the tournament organiser or any admin can delete the video record.

When a user clicks the thumbnail or title on the tournament page, an embedded player is loaded. The player can also be closed.

![image](https://cloud.githubusercontent.com/assets/242952/21458187/6238c74c-c92c-11e6-810a-bac848c2ca71.png)
![image](https://cloud.githubusercontent.com/assets/242952/21458196/746c2832-c92c-11e6-992b-e98cefdde8b6.png)
![image](https://cloud.githubusercontent.com/assets/242952/21458205/7e252540-c92c-11e6-8a91-7aa46bcefc45.png)
