### PR TITLE
Only display four videos by default

### DIFF
--- a/resources/assets/js/abr-main.js
+++ b/resources/assets/js/abr-main.js
@@ -200,6 +200,18 @@ function watchVideo(videoId) {
     }
 }
 
+function showVideoList(show) {
+    if(show) {
+        $('#showVideoList').addClass('hidden-xs-up');
+        $('#hideVideoList').removeClass('hidden-xs-up');
+        $('.hide-video').removeClass('hidden-xs-up');
+    } else {
+        $('#showVideoList').removeClass('hidden-xs-up');
+        $('#hideVideoList').addClass('hidden-xs-up');
+        $('.hide-video').addClass('hidden-xs-up');
+    }
+}
+
 // recalculating deck names from IDs while adding manually entries
 function recalculateDeckNames() {
     var corp = document.getElementById('corp_deck_identity'),

--- a/resources/views/tournaments/partials/videos.blade.php
+++ b/resources/views/tournaments/partials/videos.blade.php
@@ -1,8 +1,9 @@
-{{--table of entries for tournament details page--}}
+{{--table of videos for tournament details page--}}
+<p><b>{{ count($videos) }}</b> video{{ count($videos) != 1 ? 's' : '' }} for this tournament.</p>
 <table class="table table-sm table-striped abr-table" id="{{ $id }}">
     <tbody>
     @for ($i = 0; $i < count($videos); $i++)
-        <tr>
+        <tr class="{{ $i >= 4 ? 'hide-video hidden-xs-up' : ''}}">
             <td>
                 <a href="#" onClick="watchVideo('{{ $videos[$i]->video_id }}')">
                     <img src="{{ $videos[$i]->thumbnail_url }}"/>
@@ -30,3 +31,13 @@
     @endfor
     </tbody>
 </table>
+@if (count($videos) > 4)
+    <div>
+        <button class="btn btn-primary btn-xs" onClick="showVideoList(true)" id="showVideoList">
+            <i class="fa fa-eye" aria-hidden="true"></i> Show All Videos
+        </button>
+        <button class="btn btn-primary btn-xs hidden-xs-up" onClick="showVideoList(false)" id="hideVideoList">
+            <i class="fa fa-eye-slash" aria-hidden="true"></i> Hide Videos
+        </button>
+    </div>
+@endif


### PR DESCRIPTION
The page will only display four videos on load, hiding the others. The user can click to show/hide the excess videos. If there are fewer than five videos, the toggles are not displayed.

This should prevent the page from being overwhelmed when a lot of videos are added to a tournament.

Also displays the total count of videos above the list.

![image](https://cloud.githubusercontent.com/assets/242952/21483657/f6ec1b66-cb7d-11e6-9ab5-724e4552577a.png)

![image](https://cloud.githubusercontent.com/assets/242952/21483660/00bf3aba-cb7e-11e6-9c0b-6f50ee71d05f.png)
